### PR TITLE
Revert calculator to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
-# Calculator Web App
+# Calculator CLI
 
-This repository contains a simple Flask-based calculator. Start the server with:
-
-```bash
-python calculator.py
-```
-
-Make sure Flask is installed:
+This repository contains a simple command-line calculator. Run it with:
 
 ```bash
-pip install Flask
+python calculator.py OPERATION A B
 ```
 
-Available endpoints:
+Where `OPERATION` is one of `add`, `sub`, `mul` or `div`. `A` and `B` are
+the two numbers to operate on.
 
-- `/add?a=<num>&b=<num>`
-- `/sub?a=<num>&b=<num>`
-- `/mul?a=<num>&b=<num>`
-- `/div?a=<num>&b=<num>`
+Example:
+
+```bash
+python calculator.py add 1 2
+```
+
+will print `3.0`.

--- a/calculator.py
+++ b/calculator.py
@@ -1,8 +1,6 @@
-"""Simple calculator implemented as a Flask web app."""
+"""Simple command-line calculator."""
 
-from flask import Flask, jsonify, request
-
-app = Flask(__name__)
+import argparse
 
 
 def add(a, b):
@@ -27,59 +25,28 @@ def divide(a, b):
     return a / b
 
 
+def main(argv=None):
+    """Entry point for the command-line interface."""
+    parser = argparse.ArgumentParser(description="Simple calculator")
+    parser.add_argument(
+        "operation",
+        choices=["add", "sub", "mul", "div"],
+        help="Operation to perform",
+    )
+    parser.add_argument("a", type=float, help="First operand")
+    parser.add_argument("b", type=float, help="Second operand")
+    args = parser.parse_args(argv)
 
-def _parse_args():
-    """Parse `a` and `b` from request arguments."""
-    a = request.args.get("a", type=float)
-    b = request.args.get("b", type=float)
-    if a is None or b is None:
-        raise ValueError("Parameters 'a' and 'b' must be numbers")
-    return a, b
+    operations = {
+        "add": add,
+        "sub": subtract,
+        "mul": multiply,
+        "div": divide,
+    }
 
-
-@app.route("/add")
-def add_route():
-    """Handle addition."""
-    try:
-        a, b = _parse_args()
-        result = add(a, b)
-    except Exception as exc:
-        return jsonify({"error": str(exc)}), 400
-    return jsonify({"result": result})
-
-
-@app.route("/sub")
-def sub_route():
-    """Handle subtraction."""
-    try:
-        a, b = _parse_args()
-        result = subtract(a, b)
-    except Exception as exc:
-        return jsonify({"error": str(exc)}), 400
-    return jsonify({"result": result})
-
-
-@app.route("/mul")
-def mul_route():
-    """Handle multiplication."""
-    try:
-        a, b = _parse_args()
-        result = multiply(a, b)
-    except Exception as exc:
-        return jsonify({"error": str(exc)}), 400
-    return jsonify({"result": result})
-
-
-@app.route("/div")
-def div_route():
-    """Handle division."""
-    try:
-        a, b = _parse_args()
-        result = divide(a, b)
-    except Exception as exc:
-        return jsonify({"error": str(exc)}), 400
-    return jsonify({"result": result})
+    result = operations[args.operation](args.a, args.b)
+    print(result)
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    main()


### PR DESCRIPTION
## Summary
- remove Flask endpoints
- restore command-line interface and argparse usage
- document CLI usage in README

## Testing
- `python -m py_compile calculator.py`
- `python calculator.py sub 10 3`
